### PR TITLE
Configure Global CORS and WhiteList http://localhost:3000 for frontend

### DIFF
--- a/campusxchange/src/main/java/com/unt/campusxchange/users/config/WebConfig.java
+++ b/campusxchange/src/main/java/com/unt/campusxchange/users/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.unt.campusxchange.users.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/campusxchange/src/main/java/com/unt/campusxchange/users/controller/AuthController.java
+++ b/campusxchange/src/main/java/com/unt/campusxchange/users/controller/AuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-@CrossOrigin(origins = "http://localhost:3000")
 public class AuthController {
 
     private final AuthService authService;


### PR DESCRIPTION
### Purpose
This pull request implements centralized CORS configuration.

### Summary of changes
- Added `WebConfig.java` for CORS configuration
- Removed @CrossOrigin("http://localhost:3000") from `AuthController.java`

### Related Issues
- USER STORY-#1
- TASK- #26 